### PR TITLE
Feat: Add endpoint to get user data

### DIFF
--- a/backend/src/modules/auth/strategies/github.strategy.ts
+++ b/backend/src/modules/auth/strategies/github.strategy.ts
@@ -6,10 +6,14 @@ import { Strategy } from 'passport-github2';
 export class GithubStrategy extends PassportStrategy(Strategy, 'github') {
   constructor() {
     super({
-      clientID: process.env.GITHUB_CLIENT_ID,
-      clientSecret: process.env.GITHUB_CLIENT_SECRET,
+      clientID: process.env.GITHUB_CLIENT_ID as string,
+      clientSecret: process.env.GITHUB_CLIENT_SECRET as string,
       callbackURL: `${process.env.APP_URL}/auth/github/callback`,
       scope: ['user:email', 'read:user'],
     });
+  }
+
+  validate(): unknown {
+    throw new Error('Method not implemented.');
   }
 }

--- a/backend/src/modules/auth/strategies/jwt.strategy.ts
+++ b/backend/src/modules/auth/strategies/jwt.strategy.ts
@@ -14,12 +14,12 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
   constructor() {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
-      secretOrKey: process.env.JWT_ACCESS_SECRET,
+      secretOrKey: process.env.JWT_ACCESS_SECRET as string,
       ignoreExpiration: false,
     });
   }
 
-  async validate(payload: JwtPayload) {
+  validate(payload: JwtPayload) {
     if (payload.type && payload.type !== 'access') {
       throw new InvalidAccessTokenException();
     }

--- a/backend/src/modules/user/user.controller.ts
+++ b/backend/src/modules/user/user.controller.ts
@@ -29,9 +29,10 @@ export class UserController {
     return this.userService.findAll();
   }
 
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.userService.findOne(+id);
+  @Get('me')
+  @UseGuards(AuthGuard('jwt'))
+  findByUserId(@GetUserId() userId: string) {
+    return this.userService.findByUserId(userId);
   }
 
   @UseGuards(AuthGuard('jwt'))

--- a/backend/src/modules/user/user.service.spec.ts
+++ b/backend/src/modules/user/user.service.spec.ts
@@ -16,6 +16,7 @@ import {
 } from './exceptions/user.exceptions';
 import { AuthService } from '../auth/auth.service';
 import { compare, hash } from 'bcrypt';
+import { HttpStatus } from '@nestjs/common';
 
 jest.mock('bcrypt', () => ({
   compare: jest.fn(),
@@ -62,7 +63,7 @@ describe('UserService', () => {
     authService = module.get<AuthService>(AuthService);
   });
 
-  afterEach(() => {
+  beforeEach(() => {
     jest.clearAllMocks();
 
     userEntityMock = new User({
@@ -112,7 +113,7 @@ describe('UserService', () => {
       await expect(service.create(createUserDtoMock)).rejects.toMatchObject({
         code: UserErrorCode.EMAIL_ALREADY_EXISTS,
         message: UserErrorMessages.EMAIL_ALREADY_EXISTS,
-        status: 409,
+        status: HttpStatus.CONFLICT,
       });
 
       expect(findByEmailMethodSpy).toHaveBeenCalledWith(
@@ -134,7 +135,7 @@ describe('UserService', () => {
       await expect(service.create(createUserDtoMock)).rejects.toMatchObject({
         code: UserErrorCode.USERNAME_ALREADY_EXISTS,
         message: UserErrorMessages.USERNAME_ALREADY_EXISTS,
-        status: 409,
+        status: HttpStatus.CONFLICT,
       });
 
       expect(findByUsernameMethodSpy).toHaveBeenCalledWith(
@@ -160,10 +161,43 @@ describe('UserService', () => {
       await expect(service.create(createUserDtoMock)).rejects.toMatchObject({
         code: UserErrorCode.INVALID_PASSWORD,
         message: UserErrorMessages.INVALID_PASSWORD,
-        status: 400,
+        status: HttpStatus.BAD_REQUEST,
       });
 
       expect(repository.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findByUserId (find user by id)', () => {
+    const userId = 'user-id-mock';
+
+    it('should return user data when user exists', async () => {
+      jest.spyOn(repository, 'findByUserId').mockResolvedValue(userEntityMock);
+
+      const result = await service.findByUserId(userId);
+
+      expect(result).toBeInstanceOf(UserResponseDto);
+      expect(result.email).toEqual(userEntityMock.email);
+      expect(result.username).toEqual(userEntityMock.username);
+      expect(result).not.toHaveProperty('hashedPassword');
+
+      expect(repository.findByUserId).toHaveBeenCalledWith(userId);
+    });
+
+    it('should throw not found when user does not exist', async () => {
+      jest.spyOn(repository, 'findByUserId').mockResolvedValue(null);
+
+      await expect(service.findByUserId(userId)).rejects.toThrow(
+        UserNotFoundException,
+      );
+
+      await expect(service.findByUserId(userId)).rejects.toMatchObject({
+        code: UserErrorCode.USER_NOT_FOUND,
+        message: UserErrorMessages.USER_NOT_FOUND,
+        status: HttpStatus.NOT_FOUND,
+      });
+
+      expect(repository.findByUserId).toHaveBeenCalledWith(userId);
     });
   });
 
@@ -222,7 +256,7 @@ describe('UserService', () => {
         {
           code: UserErrorCode.USER_NOT_FOUND,
           message: UserErrorMessages.USER_NOT_FOUND,
-          status: 404,
+          status: HttpStatus.NOT_FOUND,
         },
       );
 
@@ -249,7 +283,7 @@ describe('UserService', () => {
         {
           code: UserErrorCode.USERNAME_ALREADY_EXISTS,
           message: UserErrorMessages.USERNAME_ALREADY_EXISTS,
-          status: 409,
+          status: HttpStatus.CONFLICT,
         },
       );
 
@@ -325,7 +359,7 @@ describe('UserService', () => {
       ).rejects.toMatchObject({
         code: UserErrorCode.USER_NOT_FOUND,
         message: UserErrorMessages.USER_NOT_FOUND,
-        status: 404,
+        status: HttpStatus.NOT_FOUND,
       });
 
       expect(repository.updatePasswordAndRevokeTokens).not.toHaveBeenCalled();
@@ -350,7 +384,7 @@ describe('UserService', () => {
       ).rejects.toMatchObject({
         code: UserErrorCode.INVALID_PASSWORD,
         message: UserErrorMessages.INVALID_PASSWORD,
-        status: 400,
+        status: HttpStatus.BAD_REQUEST,
       });
 
       expect(repository.updatePasswordAndRevokeTokens).not.toHaveBeenCalled();
@@ -374,7 +408,7 @@ describe('UserService', () => {
       ).rejects.toMatchObject({
         code: UserErrorCode.INVALID_PASSWORD,
         message: UserErrorMessages.INVALID_PASSWORD,
-        status: 400,
+        status: HttpStatus.BAD_REQUEST,
       });
 
       expect(repository.updatePasswordAndRevokeTokens).not.toHaveBeenCalled();

--- a/backend/src/modules/user/user.service.ts
+++ b/backend/src/modules/user/user.service.ts
@@ -59,8 +59,14 @@ export class UserService {
     return `This action returns all user`;
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} user`;
+  async findByUserId(userId: string) {
+    const userData = await this.repository.findByUserId(userId);
+
+    if (!userData) {
+      throw new UserNotFoundException();
+    }
+
+    return UserMapper.toResponse(userData);
   }
 
   async update(updateUserDto: UpdateUserDto, userId: string) {


### PR DESCRIPTION
## Descrição
Esse PR implementa a funcionalidade de busca dos dados do usuário, sendo que o usuário só pode consultar seus próprios dados. Foi implementado o seguinte endpoint:
- `GET /users/me`

**Issue:** #42 

## Mudanças feitas
- Foi implementado o endpoint que retorna os dados de acordo com User acoplado no `Request` do express.js;
- Foi implementado o serviço `findByUserId()`, que recebe o id do usuário retirado do contexto da requisição via decorator e passa para a query no banco de dados. Se o id existir, os dados salvos serão retornados e formatados para a resposta da requisição;
- Foram implementados testes unitários de "caminho feliz" e validação de exception para o serviço `findByUserId()`.