### PR TITLE
Feat: Add upvote/downvote system

### DIFF
--- a/backend/prisma/migrations/20260406181643_add_votes_modeling/migration.sql
+++ b/backend/prisma/migrations/20260406181643_add_votes_modeling/migration.sql
@@ -1,0 +1,70 @@
+/*
+  Warnings:
+
+  - You are about to drop the `Likes_Comments` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Likes_Posts` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Likes_Comments" DROP CONSTRAINT "Likes_Comments_comment_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Likes_Comments" DROP CONSTRAINT "Likes_Comments_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Likes_Posts" DROP CONSTRAINT "Likes_Posts_post_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Likes_Posts" DROP CONSTRAINT "Likes_Posts_user_id_fkey";
+
+-- AlterTable
+ALTER TABLE "Comment" ADD COLUMN     "scoreVotes" INTEGER NOT NULL DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "scoreVotes" INTEGER NOT NULL DEFAULT 0;
+
+-- DropTable
+DROP TABLE "Likes_Comments";
+
+-- DropTable
+DROP TABLE "Likes_Posts";
+
+-- CreateTable
+CREATE TABLE "PostVote" (
+    "id" TEXT NOT NULL,
+    "value" INTEGER NOT NULL DEFAULT 0,
+    "postId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PostVote_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CommentVote" (
+    "id" TEXT NOT NULL,
+    "value" INTEGER NOT NULL DEFAULT 0,
+    "commentId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "CommentVote_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PostVote_postId_userId_key" ON "PostVote"("postId", "userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CommentVote_commentId_userId_key" ON "CommentVote"("commentId", "userId");
+
+-- AddForeignKey
+ALTER TABLE "PostVote" ADD CONSTRAINT "PostVote_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PostVote" ADD CONSTRAINT "PostVote_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CommentVote" ADD CONSTRAINT "CommentVote_commentId_fkey" FOREIGN KEY ("commentId") REFERENCES "Comment"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CommentVote" ADD CONSTRAINT "CommentVote_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -34,9 +34,9 @@ model User {
   providers UserProvider[]
 
   posts         Post[]
-  likesPosts    Likes_Posts[]
+  postsVotes    PostVote[]
   postsSaves    Posts_Saves[]
-  likesComments Likes_Comments[]
+  commentsVotes CommentVote[]
 
   refreshTokens RefreshToken[]
   comments      Comment[]
@@ -65,11 +65,14 @@ model RefreshToken {
 }
 
 model Post {
-  id        String   @id @default(uuid())
-  title     String   @db.VarChar(255)
+  id        String  @id @default(uuid())
+  title     String  @db.VarChar(255)
   anonymous Boolean
-  content   String   @db.VarChar(20000)
-  views     Int      @default(0)
+  content   String  @db.VarChar(20000)
+  views     Int     @default(0)
+
+  scoreVotes Int @default(0)
+
   createdAt DateTime @default(now()) @db.Timestamp(3)
   updatedAt DateTime @default(now()) @updatedAt @db.Timestamp(3)
 
@@ -78,7 +81,7 @@ model Post {
 
   comments   Comment[]
   languages  Language[]
-  likesPosts Likes_Posts[]
+  votes      PostVote[]
   postsSaves Posts_Saves[]
 }
 
@@ -91,9 +94,12 @@ model Language {
 }
 
 model Comment {
-  id        String    @id @default(uuid())
-  content   String    @db.VarChar(10000)
-  anonymous Boolean   @default(false)
+  id        String  @id @default(uuid())
+  content   String  @db.VarChar(10000)
+  anonymous Boolean @default(false)
+
+  scoreVotes Int @default(0)
+
   createdAt DateTime  @default(now()) @db.Timestamp(3)
   updatedAt DateTime  @default(now()) @updatedAt @db.Timestamp(3)
   deletedAt DateTime? @db.Timestamp(3)
@@ -108,18 +114,36 @@ model Comment {
   parent            Comment?  @relation("CommentReplies", fields: [parent_comment_id], references: [id])
   replies           Comment[] @relation("CommentReplies")
 
-  likesComments Likes_Comments[]
+  votes CommentVote[]
 }
 
-model Likes_Posts {
-  post_id String
-  user_id String
-  is_like Boolean
+model PostVote {
+  id    String @id @default(uuid())
+  value Int    @default(0)
 
-  post Post @relation(fields: [post_id], references: [id])
-  user User @relation(fields: [user_id], references: [id])
+  postId String
+  post   Post   @relation(fields: [postId], references: [id])
 
-  @@id([post_id, user_id])
+  userId String
+  user   User   @relation(fields: [userId], references: [id])
+
+  createdAt DateTime @default(now()) @db.Timestamp(3)
+  updatedAt DateTime @default(now()) @updatedAt @db.Timestamp(3)
+
+  @@unique([postId, userId])
+}
+
+model CommentVote {
+  id    String @id @default(uuid())
+  value Int    @default(0)
+
+  commentId String
+  comment   Comment @relation(fields: [commentId], references: [id])
+
+  userId String
+  user   User   @relation(fields: [userId], references: [id])
+
+  @@unique([commentId, userId])
 }
 
 model Posts_Saves {
@@ -130,15 +154,4 @@ model Posts_Saves {
   user User @relation(fields: [user_id], references: [id])
 
   @@id([post_id, user_id])
-}
-
-model Likes_Comments {
-  comment_id String
-  user_id    String
-  is_like    Boolean
-
-  comment Comment @relation(fields: [comment_id], references: [id])
-  user    User    @relation(fields: [user_id], references: [id])
-
-  @@id([comment_id, user_id])
 }

--- a/backend/src/modules/content/comments/comments.controller.ts
+++ b/backend/src/modules/content/comments/comments.controller.ts
@@ -29,12 +29,20 @@ import { CommentErrorMessages } from 'src/common/exceptions/error-messages/comme
 import { PostErrorCode } from 'src/common/exceptions/error-codes/post-error.codes';
 import { PostErrorMessage } from 'src/common/exceptions/error-messages/post-error-messages';
 import { ApiCommentResponse } from 'src/common/decorators/swagger/api-comment-response.decorator';
+import {
+  VotesService,
+  VoteTarget,
+} from 'src/modules/engagement/votes/votes.service';
+import { VoteDto } from 'src/modules/engagement/votes/dto/vote.dto';
 
 @ApiTags('Comments | Comentários')
 @ApiExtraModels(CommentTreeResponseDto)
 @Controller('posts/:id/comments')
 export class CommentsController {
-  constructor(private readonly commentsService: CommentsService) {}
+  constructor(
+    private readonly commentsService: CommentsService,
+    private readonly votesService: VotesService,
+  ) {}
 
   @Post()
   @UseGuards(AuthGuard('jwt'))
@@ -92,6 +100,21 @@ export class CommentsController {
     return plainToInstance(CommentTreeResponseDto, commentToResponse, {
       excludeExtraneousValues: true,
     });
+  }
+
+  @Post(':commentId/vote')
+  @UseGuards(AuthGuard('jwt'))
+  async voteOnComment(
+    @Param('commentId') commentId: string,
+    @GetUserId() userId: string,
+    @Body() body: VoteDto,
+  ) {
+    return this.votesService.toggleVote(
+      userId,
+      commentId,
+      VoteTarget.COMMENT,
+      body.value,
+    );
   }
 
   @Get()

--- a/backend/src/modules/content/comments/comments.module.ts
+++ b/backend/src/modules/content/comments/comments.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { PrismaModule } from 'src/prisma/prisma.module';
 import { CommentsController } from './comments.controller';
 import { CommentsService } from './comments.service';
+import { EngagementModule } from 'src/modules/engagement/engagement.module';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, EngagementModule],
   controllers: [CommentsController],
   providers: [CommentsService],
 })

--- a/backend/src/modules/content/comments/comments.service.spec.ts
+++ b/backend/src/modules/content/comments/comments.service.spec.ts
@@ -82,6 +82,7 @@ describe('CommentsService', () => {
         createdAt: new Date(),
         updatedAt: new Date(),
         deletedAt: null,
+        scoreVotes: 0,
         user: userSelectFields,
       };
 
@@ -107,7 +108,10 @@ describe('CommentsService', () => {
           post_id: postId,
           parent_comment_id: null,
         },
-        include: commentIncludeUser,
+        include: {
+          ...commentIncludeUser,
+          votes: { where: { userId } },
+        },
       });
     });
 
@@ -127,6 +131,7 @@ describe('CommentsService', () => {
         createdAt: new Date(),
         updatedAt: new Date(),
         deletedAt: null,
+        scoreVotes: 0,
         user: userSelectFields,
       };
 
@@ -166,6 +171,7 @@ describe('CommentsService', () => {
         createdAt: new Date(),
         updatedAt: new Date(),
         deletedAt: null,
+        scoreVotes: 0,
         user: userSelectFields,
       };
 
@@ -192,7 +198,10 @@ describe('CommentsService', () => {
           post_id: postId,
           parent_comment_id: parentCommentId,
         },
-        include: commentIncludeUser,
+        include: {
+          ...commentIncludeUser,
+          votes: { where: { userId } },
+        },
       });
     });
 
@@ -289,7 +298,10 @@ describe('CommentsService', () => {
       expect(prisma.comment.findMany).toHaveBeenCalledWith({
         where: { post_id: postId },
         orderBy: { createdAt: 'asc' },
-        include: commentIncludeUser,
+        include: {
+          ...commentIncludeUser,
+          votes: { where: { userId: currentUserId } },
+        },
       });
     });
 
@@ -305,6 +317,7 @@ describe('CommentsService', () => {
           createdAt: baseMockDate,
           updatedAt: baseMockDate,
           deletedAt: null,
+          scoreVotes: 0,
           user: userSelectFields,
         },
         {
@@ -317,6 +330,7 @@ describe('CommentsService', () => {
           createdAt: baseMockDate,
           updatedAt: baseMockDate,
           deletedAt: null,
+          scoreVotes: 0,
           user: userSelectFields,
         },
       ];
@@ -352,6 +366,7 @@ describe('CommentsService', () => {
           createdAt: baseMockDate,
           updatedAt: baseMockDate,
           deletedAt: null,
+          scoreVotes: 0,
           user: userSelectFields,
         },
         {
@@ -364,6 +379,7 @@ describe('CommentsService', () => {
           createdAt: new Date('2026-01-01T01:00:00Z'),
           updatedAt: new Date('2026-01-01T01:00:00Z'),
           deletedAt: null,
+          scoreVotes: 0,
           user: userSelectFields,
         },
         {
@@ -376,6 +392,7 @@ describe('CommentsService', () => {
           createdAt: new Date('2026-01-01T02:00:00Z'),
           updatedAt: new Date('2026-01-01T02:00:00Z'),
           deletedAt: null,
+          scoreVotes: 0,
           user: userSelectFields,
         },
       ];
@@ -403,6 +420,7 @@ describe('CommentsService', () => {
           createdAt: baseMockDate,
           updatedAt: baseMockDate,
           deletedAt: null,
+          scoreVotes: 0,
           user: userSelectFields,
         },
         {
@@ -415,6 +433,7 @@ describe('CommentsService', () => {
           createdAt: new Date('2026-01-01T01:00:00Z'),
           updatedAt: new Date('2026-01-01T01:00:00Z'),
           deletedAt: null,
+          scoreVotes: 0,
           user: userSelectFields,
         },
         {
@@ -427,6 +446,7 @@ describe('CommentsService', () => {
           createdAt: new Date('2026-01-01T02:00:00Z'),
           updatedAt: new Date('2026-01-01T02:00:00Z'),
           deletedAt: null,
+          scoreVotes: 0,
           user: userSelectFields,
         },
       ];
@@ -455,6 +475,7 @@ describe('CommentsService', () => {
           createdAt: baseMockDate,
           updatedAt: baseMockDate,
           deletedAt: null,
+          scoreVotes: 0,
           user: userSelectFields,
         },
         {
@@ -467,6 +488,7 @@ describe('CommentsService', () => {
           createdAt: baseMockDate,
           updatedAt: baseMockDate,
           deletedAt: null,
+          scoreVotes: 0,
           user: userSelectFields,
         },
       ];
@@ -491,6 +513,7 @@ describe('CommentsService', () => {
           createdAt: baseMockDate,
           updatedAt: baseMockDate,
           deletedAt: null,
+          scoreVotes: 0,
           user: userSelectFields,
         },
       ];
@@ -515,6 +538,7 @@ describe('CommentsService', () => {
           createdAt: baseMockDate,
           updatedAt: baseMockDate,
           deletedAt: deletedDate,
+          scoreVotes: 0,
           user: userSelectFields,
         },
       ];
@@ -541,6 +565,7 @@ describe('CommentsService', () => {
       createdAt: new Date(),
       updatedAt: new Date(),
       deletedAt: null,
+      scoreVotes: 0,
     };
 
     it('should soft-delete a comment successfully', async () => {

--- a/backend/src/modules/content/comments/comments.service.ts
+++ b/backend/src/modules/content/comments/comments.service.ts
@@ -59,7 +59,10 @@ export class CommentsService {
         post_id: postId,
         parent_comment_id: dto.parentCommentId || null,
       },
-      include: COMMENT_INCLUDE_USER,
+      include: {
+        ...COMMENT_INCLUDE_USER,
+        votes: currentUserId ? { where: { userId: currentUserId } } : false,
+      },
     });
 
     return newComment;
@@ -69,7 +72,10 @@ export class CommentsService {
     const flatComments = await this.prisma.comment.findMany({
       where: { post_id: postId },
       orderBy: { createdAt: 'asc' },
-      include: COMMENT_INCLUDE_USER,
+      include: {
+        ...COMMENT_INCLUDE_USER,
+        votes: currentUserId ? { where: { userId: currentUserId } } : false,
+      },
     });
 
     const commentMap = new Map<string, CommentTreeNode>();
@@ -87,6 +93,8 @@ export class CommentsService {
         isOwner: comment.user_id === currentUserId,
         user: comment.user,
         replies: [],
+        scoreVotes: comment.scoreVotes,
+        votes: comment.votes,
       });
     }
 

--- a/backend/src/modules/content/comments/dto/comments.swagger.ts
+++ b/backend/src/modules/content/comments/dto/comments.swagger.ts
@@ -67,4 +67,10 @@ export const CommentTreeResponseDocs: Record<
     description: 'Lista de respostas diretas a este comentário.',
     isArray: true,
   },
+  scoreVotes: {
+    // TODO: implementar atualizações da doc swagger
+  },
+  myVote: {
+    // TODO: implementar atualizações da doc swagger
+  },
 };

--- a/backend/src/modules/content/comments/dto/response/comment-tree-response.dto.ts
+++ b/backend/src/modules/content/comments/dto/response/comment-tree-response.dto.ts
@@ -44,6 +44,15 @@ export class CommentTreeResponseDto {
   @Expose()
   anonymous: boolean;
 
+  @Expose()
+  scoreVotes: number;
+
+  @Expose()
+  @Transform(({ obj }: { obj: { votes: { value: number }[] } }) => {
+    return obj.votes?.[0]?.value ?? 0;
+  })
+  myVote: number;
+
   @ApiProperty(CommentTreeResponseDocs.createdAt)
   @Expose()
   createdAt: Date;

--- a/backend/src/modules/content/comments/interface/comments.interface.ts
+++ b/backend/src/modules/content/comments/interface/comments.interface.ts
@@ -11,6 +11,8 @@ export type CommentTreeNode = {
   isOwner: boolean;
   user: UserInclude | null;
   replies: CommentTreeNode[];
+  scoreVotes: number;
+  votes: VotesInclude[];
 };
 
 type UserInclude = {
@@ -18,4 +20,11 @@ type UserInclude = {
   user_name: string;
   user_photo: string | null;
   seniority_id: Seniority;
+};
+
+type VotesInclude = {
+  id: string;
+  userId: string;
+  value: number;
+  commentId: string;
 };

--- a/backend/src/modules/content/posts/dto/posts.swagger.ts
+++ b/backend/src/modules/content/posts/dto/posts.swagger.ts
@@ -77,6 +77,15 @@ export const PostResponseDocs: Record<PostResponseDtoKeys, ApiPropertyOptions> =
       example: ['TypeScript', 'Prisma'],
       isArray: true,
     },
+    scoreVotes: {
+      // TODO: implementar atualizações da doc swagger
+    },
+    myVote: {
+      // TODO: implementar atualizações da doc swagger
+    },
+    votes: {
+      // TODO: implementar atualizações da doc swagger
+    },
   };
 
 export const PostUserSummaryDocs = {

--- a/backend/src/modules/content/posts/dto/response/post-response.dto.ts
+++ b/backend/src/modules/content/posts/dto/response/post-response.dto.ts
@@ -12,6 +12,10 @@ import {
 } from 'class-transformer';
 import { PostResponseDocs, PostUserSummaryDocs } from '../posts.swagger';
 
+export type PostInput = Post & {
+  votes?: { value: number }[];
+};
+
 export class PostUserSummaryDto {
   @ApiProperty(PostUserSummaryDocs.id)
   id: string;
@@ -74,17 +78,30 @@ export class PostResponseDto {
   @Expose()
   readonly views: number;
 
+  @Expose()
+  readonly scoreVotes: number;
+
+  @Expose()
+  readonly myVote: number;
+
+  @Exclude()
+  readonly votes: [];
+
   @ApiProperty(PostResponseDocs.languages)
   @Expose()
   readonly languages: string[];
 
-  constructor(partial: Partial<Post>, currentUserId?: string) {
+  constructor(partial: Partial<PostInput>, currentUserId?: string) {
     Object.assign(this, partial);
 
     this.isOwner = currentUserId === this.user_id;
+
+    this.scoreVotes = partial.scoreVotes ?? 0;
+
+    this.myVote = partial.votes?.[0]?.value ?? 0;
   }
 
-  static fromArray(posts: Post[], currentUserId?: string) {
+  static fromArray(posts: PostInput[], currentUserId?: string) {
     return posts.map((post) => new PostResponseDto(post, currentUserId));
   }
 }

--- a/backend/src/modules/content/posts/entities/post.entity.ts
+++ b/backend/src/modules/content/posts/entities/post.entity.ts
@@ -6,6 +6,7 @@ export class PostEntity implements Post {
   anonymous: boolean;
   content: string;
   views: number;
+  scoreVotes: number;
   createdAt: Date;
   updatedAt: Date;
   user_id: string;

--- a/backend/src/modules/content/posts/posts.controller.ts
+++ b/backend/src/modules/content/posts/posts.controller.ts
@@ -39,6 +39,11 @@ import { RequestErrorMessages } from 'src/common/exceptions/error-messages/reque
 import { FingerprintInterceptor } from 'src/common/interceptors/fingerprint.interceptor';
 import { GetFingerprint } from 'src/common/decorators/getFingerprint.decorator';
 import { ViewsService } from 'src/modules/engagement/views/views.service';
+import { VoteDto } from 'src/modules/engagement/votes/dto/vote.dto';
+import {
+  VotesService,
+  VoteTarget,
+} from 'src/modules/engagement/votes/votes.service';
 
 @ApiTags('Posts | Postagens')
 @ApiExtraModels(PostResponseDto)
@@ -48,6 +53,7 @@ export class PostsController {
   constructor(
     private readonly postsService: PostsService,
     private readonly viewsService: ViewsService,
+    private readonly votesService: VotesService,
   ) {}
 
   @Post()
@@ -78,6 +84,21 @@ export class PostsController {
     );
 
     return new PostResponseDto(createdPost, userId);
+  }
+
+  @Post(':id/vote')
+  @UseGuards(AuthGuard('jwt'))
+  async voteOnPost(
+    @Param('id') postId: string,
+    @GetUserId() userId: string,
+    @Body() body: VoteDto,
+  ) {
+    return this.votesService.toggleVote(
+      userId,
+      postId,
+      VoteTarget.POST,
+      body.value,
+    );
   }
 
   @Get()
@@ -114,6 +135,7 @@ export class PostsController {
       query.page,
       query.limit,
       query.search,
+      userId,
     );
 
     const postsResponse = PostResponseDto.fromArray(posts, userId);
@@ -153,7 +175,7 @@ export class PostsController {
     @GetUserId() userId: string,
     @GetFingerprint() fingerprint: string,
   ) {
-    const post = await this.postsService.findOneById(postId);
+    const post = await this.postsService.findOneById(postId, userId);
 
     this.viewsService.incrementView(postId, fingerprint).catch((error) => {
       console.error('Error incrementing view:', error);

--- a/backend/src/modules/content/posts/posts.service.spec.ts
+++ b/backend/src/modules/content/posts/posts.service.spec.ts
@@ -63,6 +63,7 @@ describe('PostsService', () => {
         anonymous: createPostDto.anonymous,
         user_id: userId,
         views: 0,
+        scoreVotes: 0,
         languages: [],
         user: userSelectFields,
         createdAt: new Date(),
@@ -92,6 +93,7 @@ describe('PostsService', () => {
               seniority_id: true,
             },
           },
+          votes: { where: { userId } },
         },
       });
     });
@@ -111,6 +113,7 @@ describe('PostsService', () => {
         anonymous: createPostDto.anonymous,
         user_id: userId,
         views: 0,
+        scoreVotes: 0,
         languages: [
           { slug: 'typescript', name: 'TypeScript' },
           { slug: 'python', name: 'Python' },
@@ -154,6 +157,7 @@ describe('PostsService', () => {
               seniority_id: true,
             },
           },
+          votes: { where: { userId } },
         },
       });
     });
@@ -173,6 +177,7 @@ describe('PostsService', () => {
         anonymous: createPostDto.anonymous,
         user_id: userId,
         views: 0,
+        scoreVotes: 0,
         languages: [
           { slug: 'javascript', name: 'JavaScript' },
           { slug: 'go', name: 'Go' },
@@ -222,6 +227,7 @@ describe('PostsService', () => {
         anonymous: createPostDto.anonymous,
         user_id: userId,
         views: 0,
+        scoreVotes: 0,
         languages: [{ slug: 'typescript', name: 'TypeScript' }],
         user: userSelectFields,
         createdAt: new Date(),
@@ -264,6 +270,7 @@ describe('PostsService', () => {
         anonymous: createPostDto.anonymous,
         user_id: userId,
         views: 0,
+        scoreVotes: 0,
         languages: [],
         user: userSelectFields,
         createdAt: new Date(),
@@ -297,6 +304,7 @@ describe('PostsService', () => {
         anonymous: true,
         user_id: userId,
         views: 0,
+        scoreVotes: 0,
         languages: [],
         user: userSelectFields,
         createdAt: new Date(),
@@ -321,6 +329,7 @@ describe('PostsService', () => {
         anonymous: false,
         user_id: 'user-1',
         views: 0,
+        scoreVotes: 0,
         languages: [{ slug: 'typescript', name: 'TypeScript' }],
         user: userSelectFields,
         createdAt: new Date(),
@@ -333,6 +342,7 @@ describe('PostsService', () => {
         anonymous: true,
         user_id: 'user-2',
         views: 0,
+        scoreVotes: 0,
         languages: [],
         user: userSelectFields,
         createdAt: new Date(),
@@ -365,6 +375,7 @@ describe('PostsService', () => {
               seniority_id: true,
             },
           },
+          votes: false,
         },
       });
       expect(prisma.post.count).toHaveBeenCalledWith({ where: {} });
@@ -476,6 +487,7 @@ describe('PostsService', () => {
               seniority_id: true,
             },
           },
+          votes: false,
         },
       });
       expect(prisma.post.count).toHaveBeenCalledWith({
@@ -546,6 +558,7 @@ describe('PostsService', () => {
         anonymous: false,
         user_id: userId,
         views: 0,
+        scoreVotes: 0,
         languages: [{ slug: 'typescript', name: 'TypeScript' }],
         user: userSelectFields,
         createdAt: new Date(),
@@ -558,6 +571,7 @@ describe('PostsService', () => {
         anonymous: true,
         user_id: userId,
         views: 0,
+        scoreVotes: 0,
         languages: [],
         user: userSelectFields,
         createdAt: new Date(),
@@ -584,6 +598,7 @@ describe('PostsService', () => {
               seniority_id: true,
             },
           },
+          votes: { where: { userId } },
         },
       });
     });
@@ -625,6 +640,7 @@ describe('PostsService', () => {
         anonymous: false,
         user_id: 'user-id-mock',
         views: 5,
+        scoreVotes: 0,
         languages: [{ slug: 'typescript', name: 'TypeScript' }],
         user: userSelectFields,
         createdAt: new Date(),
@@ -648,6 +664,7 @@ describe('PostsService', () => {
               seniority_id: true,
             },
           },
+          votes: false,
         },
       });
     });
@@ -677,6 +694,7 @@ describe('PostsService', () => {
               seniority_id: true,
             },
           },
+          votes: false,
         },
       });
     });
@@ -693,6 +711,7 @@ describe('PostsService', () => {
       anonymous: false,
       user_id: userId,
       views: 0,
+      scoreVotes: 0,
       createdAt: new Date(),
       updatedAt: new Date(),
     };
@@ -737,6 +756,7 @@ describe('PostsService', () => {
               seniority_id: true,
             },
           },
+          votes: { where: { userId } },
         },
       });
     });
@@ -791,6 +811,7 @@ describe('PostsService', () => {
               seniority_id: true,
             },
           },
+          votes: { where: { userId } },
         },
       });
     });

--- a/backend/src/modules/content/posts/posts.service.ts
+++ b/backend/src/modules/content/posts/posts.service.ts
@@ -33,13 +33,21 @@ export class PostsService {
         user_id: userId,
         languages: this.buildLanguagesPayload(languages, false),
       },
-      include: POST_DEFAULT_INCLUDES,
+      include: {
+        ...POST_DEFAULT_INCLUDES,
+        votes: userId ? { where: { userId: userId } } : false,
+      },
     });
 
     return post;
   }
 
-  async findAll(page: number, limit: number, searchKey?: string) {
+  async findAll(
+    page: number,
+    limit: number,
+    searchKey?: string,
+    currentUserId?: string,
+  ) {
     const skip = (page - 1) * limit;
 
     const whereClause: Prisma.PostWhereInput = searchKey
@@ -57,17 +65,23 @@ export class PostsService {
         skip,
         take: limit,
         orderBy: { createdAt: 'desc' },
-        include: POST_DEFAULT_INCLUDES,
+        include: {
+          ...POST_DEFAULT_INCLUDES,
+          votes: currentUserId ? { where: { userId: currentUserId } } : false,
+        },
       }),
       this.prisma.post.count({ where: whereClause }),
     ]);
     return { posts, total };
   }
 
-  async findOneById(postId: string) {
+  async findOneById(postId: string, currentUserId?: string) {
     const existingPost = await this.prisma.post.findUnique({
       where: { id: postId },
-      include: POST_DEFAULT_INCLUDES,
+      include: {
+        ...POST_DEFAULT_INCLUDES,
+        votes: currentUserId ? { where: { userId: currentUserId } } : false,
+      },
     });
 
     if (!existingPost) throw new PostNotFoundException();
@@ -81,7 +95,10 @@ export class PostsService {
         user_id: userId,
       },
       orderBy: { createdAt: 'desc' },
-      include: POST_DEFAULT_INCLUDES,
+      include: {
+        ...POST_DEFAULT_INCLUDES,
+        votes: userId ? { where: { userId: userId } } : false,
+      },
     });
   }
 
@@ -104,7 +121,10 @@ export class PostsService {
         ...updatePostDto,
         languages: this.buildLanguagesPayload(updatePostDto.languages, true),
       },
-      include: POST_DEFAULT_INCLUDES,
+      include: {
+        ...POST_DEFAULT_INCLUDES,
+        votes: userId ? { where: { userId: userId } } : false,
+      },
     });
 
     return updatedPost;

--- a/backend/src/modules/engagement/engagement.module.ts
+++ b/backend/src/modules/engagement/engagement.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 import { ViewsModule } from './views/views.module';
+import { VotesModule } from './votes/votes.module';
 
 @Module({
-  imports: [ViewsModule],
-  exports: [ViewsModule],
+  imports: [ViewsModule, VotesModule],
+  exports: [ViewsModule, VotesModule],
 })
 export class EngagementModule {}

--- a/backend/src/modules/engagement/votes/dto/vote.dto.ts
+++ b/backend/src/modules/engagement/votes/dto/vote.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn, IsNumber } from 'class-validator';
+
+export class VoteDto {
+  @ApiProperty({
+    description: 'Valor do voto. Use 1 para upvote e -1 para downvote.',
+    enum: [-1, 1],
+    example: 1,
+  })
+  @IsNumber()
+  @IsIn([1, -1], {
+    message: 'Valor do voto deve ser 1 (upvote) ou -1 (downvote)',
+  })
+  value: 1 | -1;
+}

--- a/backend/src/modules/engagement/votes/votes.module.ts
+++ b/backend/src/modules/engagement/votes/votes.module.ts
@@ -1,4 +1,4 @@
 import { Module } from '@nestjs/common';
 
 @Module({})
-export class LikesModule {}
+export class VotesModule {}

--- a/backend/src/modules/engagement/votes/votes.module.ts
+++ b/backend/src/modules/engagement/votes/votes.module.ts
@@ -1,4 +1,10 @@
 import { Module } from '@nestjs/common';
+import { PrismaModule } from 'src/prisma/prisma.module';
+import { VotesService } from './votes.service';
 
-@Module({})
+@Module({
+  imports: [PrismaModule],
+  providers: [VotesService],
+  exports: [VotesService],
+})
 export class VotesModule {}

--- a/backend/src/modules/engagement/votes/votes.service.ts
+++ b/backend/src/modules/engagement/votes/votes.service.ts
@@ -1,0 +1,130 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+export enum VoteTarget {
+  POST = 'POST',
+  COMMENT = 'COMMENT',
+}
+
+@Injectable()
+export class VotesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async toggleVote(
+    userId: string,
+    targetId: string,
+    targetType: VoteTarget,
+    intendedValue: 1 | -1,
+  ) {
+    if (targetType === VoteTarget.POST) {
+      return this.handlePostVote(userId, targetId, intendedValue);
+    }
+
+    return this.handleCommentVote(userId, targetId, intendedValue);
+  }
+
+  private async handlePostVote(
+    userId: string,
+    postId: string,
+    intendedValue: 1 | -1,
+  ) {
+    return this.prisma.$transaction(async (tx) => {
+      const existingVote = await tx.postVote.findUnique({
+        where: { postId_userId: { postId, userId } },
+      });
+
+      // Remover voto
+      if (existingVote && existingVote.value === intendedValue) {
+        await tx.postVote.delete({ where: { id: existingVote.id } });
+
+        const delta = intendedValue === 1 ? -1 : 1;
+        await tx.post.update({
+          where: { id: postId },
+          data: { scoreVotes: { increment: delta } },
+        });
+
+        return { action: 'removed', scoreDelta: delta };
+      }
+
+      // Inverter voto
+      if (existingVote && existingVote.value !== intendedValue) {
+        await tx.postVote.update({
+          where: { id: existingVote.id },
+          data: { value: intendedValue },
+        });
+
+        const delta = intendedValue === 1 ? 2 : -2;
+        await tx.post.update({
+          where: { id: postId },
+          data: { scoreVotes: { increment: delta } },
+        });
+
+        return { action: 'changed', scoreDelta: delta };
+      }
+
+      // Adicionar voto
+      await tx.postVote.create({
+        data: { userId, postId, value: intendedValue },
+      });
+
+      await tx.post.update({
+        where: { id: postId },
+        data: { scoreVotes: { increment: intendedValue } },
+      });
+
+      return { action: 'created', scoreDelta: intendedValue };
+    });
+  }
+
+  private async handleCommentVote(
+    userId: string,
+    commentId: string,
+    intendedValue: 1 | -1,
+  ) {
+    return this.prisma.$transaction(async (tx) => {
+      const existingVote = await tx.commentVote.findUnique({
+        where: { commentId_userId: { commentId, userId } },
+      });
+
+      // Remover voto
+      if (existingVote && existingVote.value === intendedValue) {
+        await tx.commentVote.delete({ where: { id: existingVote.id } });
+
+        const delta = intendedValue === 1 ? -1 : 1;
+        await tx.comment.update({
+          where: { id: commentId },
+          data: { scoreVotes: { increment: delta } },
+        });
+
+        return { action: 'removed', scoreDelta: delta };
+      }
+      // Inverter voto
+      if (existingVote && existingVote.value !== intendedValue) {
+        await tx.commentVote.update({
+          where: { id: existingVote.id },
+          data: { value: intendedValue },
+        });
+
+        const delta = intendedValue === 1 ? 2 : -2;
+        await tx.comment.update({
+          where: { id: commentId },
+          data: { scoreVotes: { increment: delta } },
+        });
+
+        return { action: 'changed', scoreDelta: delta };
+      }
+
+      // Adicionar voto
+      await tx.commentVote.create({
+        data: { userId, commentId, value: intendedValue },
+      });
+
+      await tx.comment.update({
+        where: { id: commentId },
+        data: { scoreVotes: { increment: intendedValue } },
+      });
+
+      return { action: 'created', scoreDelta: intendedValue };
+    });
+  }
+}

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -1081,20 +1081,6 @@
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
-"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.23", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.28":
-  version "0.3.31"
-  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz"
-  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
-  dependencies:
-    "@jridgewell/resolve-uri" "^3.1.0"
-    "@jridgewell/sourcemap-codec" "^1.4.14"
-
-"@liaoliaots/nestjs-redis@^10.0.0":
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/@liaoliaots/nestjs-redis/-/nestjs-redis-10.0.0.tgz#4afb60bc4659fe096c603fed11f7a087de1e4712"
-  integrity sha512-uCTmlzM4q+UYADwsJEQph0mbf4u0MrktFhByi50M5fNy/+fJoWlhSqrgvjtVKjHnqydxy1gyuU6vHJEOBp9cjg==
-  dependencies:
-    tslib "2.7.0"
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
   resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz"
@@ -1110,6 +1096,13 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@liaoliaots/nestjs-redis@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@liaoliaots/nestjs-redis/-/nestjs-redis-10.0.0.tgz#4afb60bc4659fe096c603fed11f7a087de1e4712"
+  integrity sha512-uCTmlzM4q+UYADwsJEQph0mbf4u0MrktFhByi50M5fNy/+fJoWlhSqrgvjtVKjHnqydxy1gyuU6vHJEOBp9cjg==
+  dependencies:
+    tslib "2.7.0"
 
 "@lukeed/csprng@^1.0.0":
   version "1.1.0"
@@ -2867,12 +2860,6 @@ cross-spawn@^7.0.3, cross-spawn@^7.0.6:
     which "^2.0.1"
 
 debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.7, debug@^4.4.0, debug@^4.4.3:
-csstype@^3.2.2:
-  version "3.2.3"
-  resolved "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz"
-  integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
-
-debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.7, debug@^4.4.0, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==


### PR DESCRIPTION
## Descrição
Esse PR implementa o sistema de Upvote e Downvote para os posts e comentários. Os seguintes endpoints foram adicionados:
- `POST /posts/{postId}/vote`;
- `POST /posts/{postId}/comments/{commentId}/vote`.

**Issue:** #51 

## Mudanças feitas 
- Foi implementado service de votes, que disponibiliza as funcionalidades de downvote e upvote;
- Foram implementados ajustes na resposta das querys de Post e Comments. Agora elas retornam dados relacionados aos votes nos posts e comentários;
- Foram implementados ajustes no formato de resposta para os posts e a árvore de comentários, incluindo campos relacionados ao sistema de votes (score de votes do contéudo e qual o tipo de vote do usuário).